### PR TITLE
Fix for MacOS

### DIFF
--- a/piet-compiler
+++ b/piet-compiler
@@ -1,4 +1,4 @@
-#!/bin/perl -w
+#!/usr/bin/perl -w
 use strict;
 use Parse::RecDescent;
 use Data::Dumper;


### PR DESCRIPTION
Fix for error
$./piet-compiler
-bash: ./piet-compiler: /bin/perl: bad interpreter: No such file or directory